### PR TITLE
Add Feed 26: Create Affiliates

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,8 @@ Revision history for WebService-MyAffiliates
 
 {{$NEXT}}
 
+        - Add support for creating affiliate accounts.
+
 0.08      2017-02-27 06:42:57+00:00 UTC
       - Switch to dzil
 

--- a/cpanfile
+++ b/cpanfile
@@ -6,4 +6,5 @@ requires 'Mojolicious', '6.36';
 on test => sub {
     requires 'Test::More', '0.96';
     requires 'Test::Exception';
+    requires 'Test::MockModule';
 };

--- a/lib/WebService/MyAffiliates.pm
+++ b/lib/WebService/MyAffiliates.pm
@@ -7,14 +7,14 @@ our $VERSION = '0.08';
 use Carp;
 use Mojo::UserAgent;
 use Mojo::Util qw(b64_encode url_escape);
-use XML::Simple 'XMLin';    ## no critic
+use XML::Simple 'XMLin'; ## no critic
 
 use vars qw/$errstr/;
 sub errstr { return $errstr }
 
 sub new {    ## no critic (ArgUnpacking)
     my $class = shift;
-    my %args  = @_ % 2 ? %{$_[0]} : @_;
+    my %args = @_ % 2 ? %{$_[0]} : @_;
 
     for (qw/user pass host/) {
         $args{$_} || croak "Param $_ is required.";
@@ -45,7 +45,7 @@ sub __ua {
 }
 
 ## https://myaffiliates.atlassian.net/wiki/display/PUB/Feed+1%3A+Users+Feed
-sub get_users {    ## no critic (ArgUnpacking)
+sub get_users {            ## no critic (ArgUnpacking)
     my $self = shift;
     my %args = @_ % 2 ? %{$_[0]} : @_;
     my $url  = Mojo::URL->new('/feeds.php?FEED_ID=1');
@@ -55,8 +55,8 @@ sub get_users {    ## no critic (ArgUnpacking)
 
 sub create_affiliate {
     my $self = shift;
-    my $args = shift;
-    croak 'A hashref was expected as parameter' unless ref $args eq ref {};
+    my $args = @_ % 2 ? %{$_[0]} : @_;
+    croak 'A hashref was expected as parameter' unless ref $args eq 'HASH';
     my $parameters = {};
     for my $arg (keys(${args}->%*)) {
         $parameters->{'PARAM_' . $arg} = $args->{$arg};
@@ -68,7 +68,7 @@ sub create_affiliate {
 
     my $error_count = $res->{INIT}->{ERROR_COUNT};
     if ($error_count) {
-        my $init   = $res->{INIT};
+        my $init = $res->{INIT};
         my @errors = ref $init->{ERROR} eq 'ARRAY' ? $init->{ERROR}->@* : ($init->{ERROR});
         $errstr = map { $_->{MSG} . " " . $_->{DETAIL} } @errors;
         return;
@@ -82,14 +82,14 @@ sub create_affiliate {
 sub get_user {
     my ($self, $id) = @_;
 
-    $id                                         or croak "id is required.";
+    $id or croak "id is required.";
     my $user = $self->get_users(USER_ID => $id) or return;
     return $user->{USER};
 }
 
 ## https://myaffiliates.atlassian.net/wiki/display/PUB/Feed+4%3A+Decode+Token
 sub decode_token {
-    my $self   = shift;
+    my $self = shift;
     my @tokens = @_ or croak 'Must pass at least one token.';
 
     return $self->request('/feeds.php?FEED_ID=4&TOKENS=' . url_escape(join(',', @tokens)));
@@ -128,10 +128,9 @@ sub get_customers {    ## no critic (ArgUnpacking)
     $url->query(\%args) if %args;
     my $res = $self->request($url->to_string);
 
-    my $customers =
-         !exists $res->{PLAYER}         ? []
-        : ref $res->{PLAYER} eq 'ARRAY' ? $res->{PLAYER}
-        :                                 [$res->{PLAYER}];
+    my $customers = !exists $res->{PLAYER}        ? []
+                  : ref $res->{PLAYER} eq 'ARRAY' ? $res->{PLAYER}
+                  :                                 [$res->{PLAYER}];
 
     return $customers;
 }

--- a/lib/WebService/MyAffiliates.pm
+++ b/lib/WebService/MyAffiliates.pm
@@ -7,14 +7,14 @@ our $VERSION = '0.08';
 use Carp;
 use Mojo::UserAgent;
 use Mojo::Util qw(b64_encode url_escape);
-use XML::Simple 'XMLin'; ## no critic
+use XML::Simple 'XMLin';    ## no critic
 
 use vars qw/$errstr/;
 sub errstr { return $errstr }
 
 sub new {    ## no critic (ArgUnpacking)
     my $class = shift;
-    my %args = @_ % 2 ? %{$_[0]} : @_;
+    my %args  = @_ % 2 ? %{$_[0]} : @_;
 
     for (qw/user pass host/) {
         $args{$_} || croak "Param $_ is required.";
@@ -45,7 +45,7 @@ sub __ua {
 }
 
 ## https://myaffiliates.atlassian.net/wiki/display/PUB/Feed+1%3A+Users+Feed
-sub get_users {            ## no critic (ArgUnpacking)
+sub get_users {    ## no critic (ArgUnpacking)
     my $self = shift;
     my %args = @_ % 2 ? %{$_[0]} : @_;
     my $url  = Mojo::URL->new('/feeds.php?FEED_ID=1');
@@ -53,17 +53,43 @@ sub get_users {            ## no critic (ArgUnpacking)
     return $self->request($url->to_string);
 }
 
+sub create_affiliate {
+    my $self = shift;
+    my $args = shift;
+    die 'A hashref was expected as parameter', unless $args;
+    my $parameters = {};
+    for my $arg (keys(${args}->%*)) {
+        $parameters->{'PARAM_' . $arg} = $args->{$arg};
+    }
+
+    my $url = Mojo::URL->new('/feeds.php?FEED_ID=26');
+    $url->query($parameters);
+    my $res = $self->request($url->to_string);
+
+    my $error_count = $res->{INIT}->{ERROR_COUNT};
+    if ($error_count) {
+        my $init   = $res->{INIT};
+        my @errors = ref $init->{ERROR} eq 'ARRAY' ? $init->{ERROR}->@* : ($init->{ERROR});
+        $errstr = map { $_->{MSG} . " " . $_->{DETAIL} } @errors;
+        return;
+    }
+
+    delete $res->{PASSWORD};
+
+    return $res;
+}
+
 sub get_user {
     my ($self, $id) = @_;
 
-    $id or croak "id is required.";
+    $id                                         or croak "id is required.";
     my $user = $self->get_users(USER_ID => $id) or return;
     return $user->{USER};
 }
 
 ## https://myaffiliates.atlassian.net/wiki/display/PUB/Feed+4%3A+Decode+Token
 sub decode_token {
-    my $self = shift;
+    my $self   = shift;
     my @tokens = @_ or croak 'Must pass at least one token.';
 
     return $self->request('/feeds.php?FEED_ID=4&TOKENS=' . url_escape(join(',', @tokens)));
@@ -102,9 +128,10 @@ sub get_customers {    ## no critic (ArgUnpacking)
     $url->query(\%args) if %args;
     my $res = $self->request($url->to_string);
 
-    my $customers = !exists $res->{PLAYER}        ? []
-                  : ref $res->{PLAYER} eq 'ARRAY' ? $res->{PLAYER}
-                  :                                 [$res->{PLAYER}];
+    my $customers =
+         !exists $res->{PLAYER}         ? []
+        : ref $res->{PLAYER} eq 'ARRAY' ? $res->{PLAYER}
+        :                                 [$res->{PLAYER}];
 
     return $customers;
 }
@@ -245,6 +272,54 @@ Feed 10: User Customers Feed.
 Returns Array ref with customer list.
 
     my $customers = $aff->get_customers( AFFILIATE_ID => $affiliate_id );
+
+
+=head2 create_affiliate 
+
+Feed 26:Create Affiliate 
+
+L<https://myaffiliates.atlassian.net/wiki/display/PUB/Feed+26%3A+Create+Affiliate>
+
+    my $res = $aff->create_affiliate({
+        'first_name'     => 'Chales',
+        'last_name'     => 'Babbage',
+        'date_of_birth' => '1871-10-18',
+        'individual'    => 'individual',
+        'phone_number'  => '+4412341234',
+        'address'       => 'Some street',
+        'city'          => 'Some City',
+        'state'         => 'Some State',
+        'postcode'      => '1234',
+        'website'       => 'https://www.example.com/',
+        'agreement'     => 1,
+        'username'      => 'charles_babbage.com',
+        'email'         => 'charles@babbage.com',
+        'country'       => 'GB',
+        'password'      => 's3cr3t',
+        'plans'         => '2,4'
+    });
+
+    $res->{USERID};
+
+It expects a hashref with all the required parameters for account creation. Other fields may be required depending on your installation.
+
+=over 4
+
+=item * username: A non-empty string with the username, must be an alphanumeric unique string.
+
+=item * password: A non-empty string with the password, following configured the password policy.
+
+=item * email: A non-empty string with a valid e-mail account. It must be unique.
+
+=item * referrer_token: Optional. A non-empty string with subaffiliate token.
+
+=item * plans: Optional. A non-empty string with CSV with the channel numeric IDs to subscribe the client. MyAffiliates will also subscribe the client to any default channel unless B<PLAN_FORCE> is set to 1.
+
+=item * PLAN_FORCE: Optional. For use with plans, if 1 is set here the client will be subscribe to the channels listed in C<plans> parameters only, and won't be subscribed to any other channel. By default this is is 0.
+
+=back
+
+Returns a hashref with the details for the created account, in particular a numeric user_id will be returned in the hashref.
 
 =head2 errstr
 

--- a/lib/WebService/MyAffiliates.pm
+++ b/lib/WebService/MyAffiliates.pm
@@ -56,7 +56,7 @@ sub get_users {    ## no critic (ArgUnpacking)
 sub create_affiliate {
     my $self = shift;
     my $args = shift;
-    die 'A hashref was expected as parameter' unless ref $args eq ref {};
+    croak 'A hashref was expected as parameter' unless ref $args eq ref {};
     my $parameters = {};
     for my $arg (keys(${args}->%*)) {
         $parameters->{'PARAM_' . $arg} = $args->{$arg};

--- a/lib/WebService/MyAffiliates.pm
+++ b/lib/WebService/MyAffiliates.pm
@@ -274,9 +274,9 @@ Returns Array ref with customer list.
     my $customers = $aff->get_customers( AFFILIATE_ID => $affiliate_id );
 
 
-=head2 create_affiliate 
+=head2 create_affiliate
 
-Feed 26:Create Affiliate 
+Feed 26:Create Affiliate
 
 L<https://myaffiliates.atlassian.net/wiki/display/PUB/Feed+26%3A+Create+Affiliate>
 

--- a/lib/WebService/MyAffiliates.pm
+++ b/lib/WebService/MyAffiliates.pm
@@ -56,7 +56,7 @@ sub get_users {    ## no critic (ArgUnpacking)
 sub create_affiliate {
     my $self = shift;
     my $args = shift;
-    die 'A hashref was expected as parameter', unless $args;
+    die 'A hashref was expected as parameter' unless ref $args eq ref {};
     my $parameters = {};
     for my $arg (keys(${args}->%*)) {
         $parameters->{'PARAM_' . $arg} = $args->{$arg};

--- a/lib/WebService/MyAffiliates.pm
+++ b/lib/WebService/MyAffiliates.pm
@@ -53,7 +53,7 @@ sub get_users {            ## no critic (ArgUnpacking)
     return $self->request($url->to_string);
 }
 
-sub create_affiliate {
+sub create_affiliate {            ## no critic (ArgUnpacking)
     my $self = shift;
     my %args = @_ % 2 ? %{$_[0]} : @_;
     my $parameters = +{map { ('PARAM_' . $_ => $args{$_}) } keys %args};

--- a/t/basic.t
+++ b/t/basic.t
@@ -11,6 +11,7 @@ my $aff = WebService::MyAffiliates->new(
 ok($aff);
 
 throws_ok { $aff->decode_token() } qr/Must pass at least one token/;
-throws_ok { $aff->get_affiliate_id_from_token() } qr/Must pass a token to get_affiliate_id_from_token/, 'Throws exception if no token given.';
+throws_ok { $aff->get_affiliate_id_from_token() } qr/Must pass a token to get_affiliate_id_from_token/, 
+    'Throws exception if no token given.';
 
 done_testing;

--- a/t/basic.t
+++ b/t/basic.t
@@ -12,6 +12,6 @@ ok($aff);
 
 throws_ok { $aff->decode_token() } qr/Must pass at least one token/;
 throws_ok { $aff->get_affiliate_id_from_token() } qr/Must pass a token to get_affiliate_id_from_token/, 
-    'Throws exception if no token given.';
+     'Throws exception if no token given.';
 
 done_testing;

--- a/t/basic.t
+++ b/t/basic.t
@@ -12,6 +12,6 @@ ok($aff);
 
 throws_ok { $aff->decode_token() } qr/Must pass at least one token/;
 throws_ok { $aff->get_affiliate_id_from_token() } qr/Must pass a token to get_affiliate_id_from_token/, 
-     'Throws exception if no token given.';
+      'Throws exception if no token given.';
 
 done_testing;

--- a/t/basic.t
+++ b/t/basic.t
@@ -11,7 +11,7 @@ my $aff = WebService::MyAffiliates->new(
 ok($aff);
 
 throws_ok { $aff->decode_token() } qr/Must pass at least one token/;
-throws_ok { $aff->get_affiliate_id_from_token() } qr/Must pass a token to get_affiliate_id_from_token/, 
+throws_ok { $aff->get_affiliate_id_from_token() } qr/Must pass a token to get_affiliate_id_from_token/,
       'Throws exception if no token given.';
 
 done_testing;

--- a/t/create_affiliate.t
+++ b/t/create_affiliate.t
@@ -1,0 +1,45 @@
+#!/usr/bin/perl
+
+use strict;
+# use warnings;
+use WebService::MyAffiliates;
+use Test::More;
+
+plan skip_all => "ENV MYAFFILIATES_USER/MYAFFILIATES_PASS/MYAFFILIATES_HOST is required to continue."
+    unless $ENV{MYAFFILIATES_USER}
+    and $ENV{MYAFFILIATES_PASS}
+    and $ENV{MYAFFILIATES_HOST};
+my $aff = WebService::MyAffiliates->new(
+    user => $ENV{MYAFFILIATES_USER},
+    pass => $ENV{MYAFFILIATES_PASS},
+    host => $ENV{MYAFFILIATES_HOST});
+
+my $res = $aff->create_affiliate({'incomplete' => 'params'});
+
+ok(!$res, 'Returns undef if incomplete parameters are passed');
+
+$res = $aff->create_affiliate({
+    'first_name'    => 'Chales',
+    'last_name'     => 'Babbage',
+    'date_of_birth' => '1871-10-18',
+    'individual'    => 1,
+    'phone_number'  => '+4412341234',
+    'address'       => 'Some street',
+    'city'          => 'Some City',
+    'state'         => 'Some State',
+    'postcode'      => '1234',
+    'website'       => 'https://locahost.com/',
+    'agreement'     => 1,
+    'username'      => 'charles_babbage.com',
+    'email'         => 'charles@babbage.com',
+    'country'       => 'GB',
+    'password'      => 's3cr3t',
+    'individual'    => 'individual',
+    'plans'         => '2,4',
+});
+
+ok($res, 'Returns the created account');
+
+done_testing();
+
+1;

--- a/t/create_affiliate.t
+++ b/t/create_affiliate.t
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 
 use strict;
-# use warnings;
+use warnings;
 use WebService::MyAffiliates;
 use Test::More;
 

--- a/t/create_affiliate.t
+++ b/t/create_affiliate.t
@@ -18,28 +18,6 @@ my $res = $aff->create_affiliate({'incomplete' => 'params'});
 
 ok(!$res, 'Returns undef if incomplete parameters are passed');
 
-$res = $aff->create_affiliate({
-    'first_name'    => 'Chales',
-    'last_name'     => 'Babbage',
-    'date_of_birth' => '1871-10-18',
-    'individual'    => 1,
-    'phone_number'  => '+4412341234',
-    'address'       => 'Some street',
-    'city'          => 'Some City',
-    'state'         => 'Some State',
-    'postcode'      => '1234',
-    'website'       => 'https://locahost.com/',
-    'agreement'     => 1,
-    'username'      => 'charles_babbage.com',
-    'email'         => 'charles@babbage.com',
-    'country'       => 'GB',
-    'password'      => 's3cr3t',
-    'individual'    => 'individual',
-    'plans'         => '2,4',
-});
-
-ok($res, 'Returns the created account');
-
 done_testing();
 
 1;

--- a/t/create_affiliate.t
+++ b/t/create_affiliate.t
@@ -13,8 +13,6 @@ my $aff = WebService::MyAffiliates->new(
     host => 'host'
 );
 
-throws_ok { $aff->create_affiliate(undef) } qr/A hashref was expected as parameter/, 'Throws error if undef parameter';
-
 my $mock_aff = Test::MockModule->new('WebService::MyAffiliates');
 
 $mock_aff->mock(
@@ -23,12 +21,18 @@ $mock_aff->mock(
         return +{
             'INIT' => {
                 'ERROR_COUNT' => 0,
-                'WARNING_COUNT'
+                'WARNING_COUNT' => 0,
             }};
 
     });
 
-ok($aff->create_affiliate({}), 'hashref valid parameter');
+ok($aff->create_affiliate({}), 'A hashref is a valid parameter');
+
+my $hash_params = (
+   first_name => 'Dummy' 
+);
+
+ok($aff->create_affiliate({}), 'A hash is a valid parameter');
 
 $mock_aff->mock(
     'request',

--- a/t/create_affiliate.t
+++ b/t/create_affiliate.t
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 use WebService::MyAffiliates;
 use Test::More;
+use Test::MockModule qw/strict/;
 
 plan skip_all => "ENV MYAFFILIATES_USER/MYAFFILIATES_PASS/MYAFFILIATES_HOST is required to continue."
     unless $ENV{MYAFFILIATES_USER}
@@ -17,6 +18,65 @@ my $aff = WebService::MyAffiliates->new(
 my $res = $aff->create_affiliate({'incomplete' => 'params'});
 
 ok(!$res, 'Returns undef if incomplete parameters are passed');
+
+my $mock_aff = Test::MockModule->new('WebService::MyAffiliates');
+
+$mock_aff->mock(
+    'request',
+    sub {
+        return +{
+            'INIT' => {
+                'ERROR_COUNT' => 1,
+                'ERROR'       => {
+                    'MSG'    => 'An account with this email already exists.',
+                    'DETAIL' => 'email'
+                }}};
+
+    });
+
+my $args = {
+    'first_name'    => 'Charles',
+    'last_name'     => 'Babbage',
+    'date_of_birth' => '1871-10-18',
+    'individual'    => 'individual',
+    'phone_number'  => '+4412341234',
+    'address'       => 'Some street',
+    'city'          => 'Some City',
+    'state'         => 'Some State',
+    'postcode'      => '1234',
+    'website'       => 'https://www.example.com/',
+    'agreement'     => 1,
+    'username'      => 'charles_babbage.com',
+    'email'         => 'repeated@email.com',
+    'country'       => 'GB',
+    'password'      => 's3cr3t',
+    'plans'         => '2,4',
+};
+
+$res = $aff->create_affiliate($args);
+
+ok(!$res, 'Returns undef in case of a single error');
+
+$mock_aff->mock(
+    'request',
+    sub {
+        return +{
+            'INIT' => {
+                'ERROR_COUNT' => 2,
+                'ERROR'       => [{
+                        'MSG'    => 'An account with this email already exists.',
+                        'DETAIL' => 'email'
+                    },
+                    {
+                        'DETAIL' => 'username',
+                        'MSG'    => 'Username not available'
+                    }]}};
+
+    });
+
+$res = $aff->create_affiliate($args);
+
+ok(!$res, 'Returns undef in case of multiple errors');
 
 done_testing();
 

--- a/t/decode_token.t
+++ b/t/decode_token.t
@@ -6,13 +6,12 @@ use WebService::MyAffiliates;
 use Test::More;
 
 plan skip_all => "ENV MYAFFILIATES_USER/MYAFFILIATES_PASS/MYAFFILIATES_HOST is required to continue."
-    unless $ENV{MYAFFILIATES_USER}
-    and $ENV{MYAFFILIATES_PASS}
-    and $ENV{MYAFFILIATES_HOST};
+    unless $ENV{MYAFFILIATES_USER} and $ENV{MYAFFILIATES_PASS} and $ENV{MYAFFILIATES_HOST};
 my $aff = WebService::MyAffiliates->new(
     user => $ENV{MYAFFILIATES_USER},
     pass => $ENV{MYAFFILIATES_PASS},
-    host => $ENV{MYAFFILIATES_HOST});
+    host => $ENV{MYAFFILIATES_HOST
+);
 
 my $token_info = $aff->decode_token('PQ4YXsO2q5mVAv0U_Fv2nWNd7ZgqdRLk');
 # use Data::Dumper;

--- a/t/decode_token.t
+++ b/t/decode_token.t
@@ -10,7 +10,7 @@ plan skip_all => "ENV MYAFFILIATES_USER/MYAFFILIATES_PASS/MYAFFILIATES_HOST is r
 my $aff = WebService::MyAffiliates->new(
     user => $ENV{MYAFFILIATES_USER},
     pass => $ENV{MYAFFILIATES_PASS},
-    host => $ENV{MYAFFILIATES_HOST
+    host => $ENV{MYAFFILIATES_HOST}
 );
 
 my $token_info = $aff->decode_token('PQ4YXsO2q5mVAv0U_Fv2nWNd7ZgqdRLk');

--- a/t/get_users.t
+++ b/t/get_users.t
@@ -6,13 +6,12 @@ use WebService::MyAffiliates;
 use Test::More;
 
 plan skip_all => "ENV MYAFFILIATES_USER/MYAFFILIATES_PASS/MYAFFILIATES_HOST is required to continue."
-    unless $ENV{MYAFFILIATES_USER}
-    and $ENV{MYAFFILIATES_PASS}
-    and $ENV{MYAFFILIATES_HOST};
+    unless $ENV{MYAFFILIATES_USER} and $ENV{MYAFFILIATES_PASS} and $ENV{MYAFFILIATES_HOST};
 my $aff = WebService::MyAffiliates->new(
     user => $ENV{MYAFFILIATES_USER},
     pass => $ENV{MYAFFILIATES_PASS},
-    host => $ENV{MYAFFILIATES_HOST});
+    host => $ENV{MYAFFILIATES_HOST}
+);
 
 my $user_info = $aff->get_user(2);
 


### PR DESCRIPTION
Adds a new method for MyAffiliates account creation

```perl
use WebService::MyAffiliates;

my $aff = WebService::MyAffiliates->new(
    user => 'user',
    pass => 'awesome_pass',
    host => 'https://awesome.host.com/');

my $res = $aff->create_affiliate({
      'first_name'     => 'Chales',
      'last_name'     => 'Babbage',
      'date_of_birth' => '1871-10-18',
      'individual'    => 'individual',
      'phone_number'  => '+4412341234',
      'address'       => 'Some street',
      'city'          => 'Some City',
      'state'         => 'Some State',
      'postcode'      => '1234',
      'website'       => 'https://www.example.com/',
      'agreement'     => 1,
      'username'      => 'charles_babbage.com',
      'email'         => 'charles@babbage.com',
      'country'       => 'GB',
      'password'      => 's3cr3t',
      'plans'         => '2,4'
  });

die 'something failed' unless $res;

$res->{USERID};
```